### PR TITLE
refactor

### DIFF
--- a/SnakeController/SnakeController.cpp
+++ b/SnakeController/SnakeController.cpp
@@ -63,7 +63,7 @@ Controller::Controller(IPort& p_displayPort, IPort& p_foodPort, IPort& p_scorePo
     }
 }
 
-void Controller::handleTimePassed(const TimeoutInd&)
+void Controller::handleTimePassed()
 {
     Segment newHead = getNewHead();
 
@@ -215,23 +215,30 @@ Controller::Segment Controller::getNewHead() const
 
 void Controller::receive(std::unique_ptr<Event> e)
 {
-    try {
-        handleTimePassed(*dynamic_cast<EventT<TimeoutInd> const&>(*e));
-    } catch (std::bad_cast&) {
-        try {
-            handleDirectionChange(*dynamic_cast<EventT<DirectionInd> const&>(*e));
-        } catch (std::bad_cast&) {
-            try {
-                handleFoodPositionChange(*dynamic_cast<EventT<FoodInd> const&>(*e));
-            } catch (std::bad_cast&) {
-                try {
-                    handleNewFood(*dynamic_cast<EventT<FoodResp> const&>(*e));
-                } catch (std::bad_cast&) {
-                    throw UnexpectedEventException();
-                }
-            }
-        }
+    if(e->getMessageId() == TimeoutInd::MESSAGE_ID)
+    {
+        handleTimePassed();
+
     }
+    
+    
+    // try {
+    //     handleTimePassed(*dynamic_cast<EventT<TimeoutInd> const&>(*e));
+    // } catch (std::bad_cast&) {
+    //     try {
+    //         handleDirectionChange(*dynamic_cast<EventT<DirectionInd> const&>(*e));
+    //     } catch (std::bad_cast&) {
+    //         try {
+    //             handleFoodPositionChange(*dynamic_cast<EventT<FoodInd> const&>(*e));
+    //         } catch (std::bad_cast&) {
+    //             try {
+    //                 handleNewFood(*dynamic_cast<EventT<FoodResp> const&>(*e));
+    //             } catch (std::bad_cast&) {
+    //                 throw UnexpectedEventException();
+    //             }
+    //         }
+    //     }
+    // }
 }
 
 } // namespace Snake

--- a/SnakeController/SnakeController.hpp
+++ b/SnakeController/SnakeController.hpp
@@ -33,7 +33,7 @@ public:
     void receive(std::unique_ptr<Event> e) override;
 
 private:
-    void handleTimePassed(const TimeoutInd&);
+    void handleTimePassed();
     void handleDirectionChange(const DirectionInd&);
     void handleFoodPositionChange(const FoodInd& receivedFood);
     void handleNewFood(const FoodResp& requestedFood);


### PR DESCRIPTION
Usuniety dynamic cast z wywolania metody handleTimePassed. Sprawdzanie  eventow za pomoca getMessageID zamiast dynamic cast. Reszta powinna byc wykonana analoicznie